### PR TITLE
Add simple LED blink example for MachXO3LF board

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# MACHX03 FPGA project
+# MACHX03 Blinky Example
+
+This repository contains a minimal LED blink design for the
+MachXO3LF-6900C-S-EVN evaluation board.
+
+## Contents
+
+- `src/blinky.v` – Verilog source for the top-level blink module.
+- `constraints/blinky.lpf` – Example constraint file. Update pin
+  assignments according to your board documentation.
+- `scripts/build.tcl` – TCL script to build the project using
+  Lattice Diamond.
+- `scripts/build.sh` – Helper shell script that invokes the TCL script.
+
+## Building
+
+1. Install Lattice Diamond and ensure the command-line tools are in your
+   `PATH`.
+2. From the repository root run:
+
+```sh
+sh scripts/build.sh
+```
+
+This will create `blinky.bit` in the current directory. Program the board
+with the generated bitstream using Diamond Programmer or `openFPGALoader`.
+
+

--- a/constraints/blinky.lpf
+++ b/constraints/blinky.lpf
@@ -1,0 +1,8 @@
+# Constraints for MachXO3LF-6900C-S-EVN
+# Replace pin locations with values from the board documentation.
+
+IOBUF PORT "clk" IO_TYPE=LVCMOS33 ;
+LOCATE COMP "clk" SITE "??";
+
+IOBUF PORT "led" IO_TYPE=LVCMOS33 ;
+LOCATE COMP "led" SITE "??";

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Run the Diamond TCL script to build the design
+# Ensure Diamond's bin directory is in your PATH.
+
+tclsh scripts/build.tcl
+

--- a/scripts/build.tcl
+++ b/scripts/build.tcl
@@ -1,0 +1,12 @@
+# Lattice Diamond batch script for MachXO3LF-6900C-S-EVN
+# Create project and build bitstream
+
+prj_project create blinky -family MachXO3L -device LCMXO3LF-6900C-5BG256C -impl impl1 -top blinky
+prj_source add src/blinky.v
+prj_constraint add constraints/blinky.lpf
+
+prj_run Synthesis -impl impl1
+prj_run Map -impl impl1
+prj_run PAR -impl impl1
+prj_run Export -impl impl1 -format bit -bitstream_file blinky.bit
+

--- a/src/blinky.v
+++ b/src/blinky.v
@@ -1,0 +1,15 @@
+// Simple LED blink example
+
+module blinky(
+    input wire clk,
+    output wire led
+    );
+
+    reg [23:0] counter = 24'd0;
+
+    always @(posedge clk) begin
+        counter <= counter + 1'b1;
+    end
+
+    assign led = counter[23];
+endmodule


### PR DESCRIPTION
## Summary
- add a simple blinky module in `src/blinky.v`
- provide placeholder constraints in `constraints/blinky.lpf`
- include Diamond build scripts under `scripts/`
- update README with usage instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b37481af8832cbb241891a94f7f2a